### PR TITLE
Fix demo notebook: handle schema drift, silence HF_TOKEN warning

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-03-18T12:47:28.692345Z",
@@ -42,22 +42,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import re\n",
-    "import duckdb\n",
-    "import pandas as pd\n",
-    "import plotly.express as px\n",
-    "import plotly.graph_objects as go\n",
-    "from huggingface_hub import list_repo_files\n",
-    "from great_tables import GT\n",
-    "import base64\n",
-    "from IPython.display import HTML, display\n",
-    "\n",
-    "def download_csv(df, filename):\n",
-    "    csv = df.to_csv(index=False)\n",
-    "    b64 = base64.b64encode(csv.encode()).decode()\n",
-    "    display(HTML(f'<a href=\"data:file/csv;base64,{b64}\" download=\"{filename}\" style=\"background:#4CAF50;color:white;padding:8px 16px;text-decoration:none;border-radius:4px;display:inline-block;margin:10px 0;\">Download {filename}</a>'))"
-   ]
+   "source": "import os\n# Public datasets — no auth needed. Skip Colab's HF_TOKEN lookup to silence its warning.\nos.environ[\"HF_HUB_DISABLE_IMPLICIT_TOKEN\"] = \"1\"\n\nimport re\nimport duckdb\nimport pandas as pd\nimport plotly.express as px\nimport plotly.graph_objects as go\nfrom huggingface_hub import list_repo_files\nfrom great_tables import GT\nimport base64\nfrom IPython.display import HTML, display\n\ndef download_csv(df, filename):\n    csv = df.to_csv(index=False)\n    b64 = base64.b64encode(csv.encode()).decode()\n    display(HTML(f'<a href=\"data:file/csv;base64,{b64}\" download=\"{filename}\" style=\"background:#4CAF50;color:white;padding:8px 16px;text-decoration:none;border-radius:4px;display:inline-block;margin:10px 0;\">Download {filename}</a>'))"
   },
   {
    "cell_type": "markdown",
@@ -93,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-03-18T12:47:29.711654Z",
@@ -102,42 +87,8 @@
      "shell.execute_reply": "2026-03-18T12:47:33.727311Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded 2 months: 202512 - 202601\n",
-      "  Accessions: 25,799 records\n",
-      "  Separations: 70,453 records\n",
-      "  Employment: 4,109,993 records\n",
-      "CPU times: user 1.69 s, sys: 124 ms, total: 1.81 s\n",
-      "Wall time: 4.01 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "N_MONTHS = 2  # most recent months per data type (6 files total)\n",
-    "db = duckdb.connect()\n",
-    "\n",
-    "acc_list = \", \".join(f\"'{u}'\" for u in acc_urls[-N_MONTHS:])\n",
-    "db.execute(f\"CREATE TABLE accessions AS SELECT * FROM read_parquet([{acc_list}])\")\n",
-    "\n",
-    "sep_list = \", \".join(f\"'{u}'\" for u in sep_urls[-N_MONTHS:])\n",
-    "db.execute(f\"CREATE TABLE separations AS SELECT * FROM read_parquet([{sep_list}])\")\n",
-    "\n",
-    "emp_list = \", \".join(f\"'{u}'\" for u in emp_urls[-N_MONTHS:])\n",
-    "db.execute(f\"CREATE VIEW employment AS SELECT * FROM read_parquet([{emp_list}])\")\n",
-    "\n",
-    "acc_count = db.execute(\"SELECT SUM(CAST(count AS INTEGER)) FROM accessions\").fetchone()[0]\n",
-    "sep_count = db.execute(\"SELECT SUM(CAST(count AS INTEGER)) FROM separations\").fetchone()[0]\n",
-    "emp_count = db.execute(\"SELECT SUM(CAST(count AS INTEGER)) FROM employment\").fetchone()[0]\n",
-    "print(f\"Loaded {N_MONTHS} months: {acc_months[-N_MONTHS]} - {acc_months[-1]}\")\n",
-    "print(f\"  Accessions: {acc_count:,} records\")\n",
-    "print(f\"  Separations: {sep_count:,} records\")\n",
-    "print(f\"  Employment: {emp_count:,} records\")"
-   ]
+   "outputs": [],
+   "source": "%%time\nN_MONTHS = 2  # most recent months per data type (6 files total)\ndb = duckdb.connect()\n\n# union_by_name=True tolerates schema drift between months (OPM occasionally adds/removes columns)\nacc_list = \", \".join(f\"'{u}'\" for u in acc_urls[-N_MONTHS:])\ndb.execute(f\"CREATE TABLE accessions AS SELECT * FROM read_parquet([{acc_list}], union_by_name=True)\")\n\nsep_list = \", \".join(f\"'{u}'\" for u in sep_urls[-N_MONTHS:])\ndb.execute(f\"CREATE TABLE separations AS SELECT * FROM read_parquet([{sep_list}], union_by_name=True)\")\n\nemp_list = \", \".join(f\"'{u}'\" for u in emp_urls[-N_MONTHS:])\ndb.execute(f\"CREATE VIEW employment AS SELECT * FROM read_parquet([{emp_list}], union_by_name=True)\")\n\nacc_count = db.execute(\"SELECT SUM(CAST(count AS INTEGER)) FROM accessions\").fetchone()[0]\nsep_count = db.execute(\"SELECT SUM(CAST(count AS INTEGER)) FROM separations\").fetchone()[0]\nemp_count = db.execute(\"SELECT SUM(CAST(count AS INTEGER)) FROM employment\").fetchone()[0]\nprint(f\"Loaded {N_MONTHS} months: {acc_months[-N_MONTHS]} - {acc_months[-1]}\")\nprint(f\"  Accessions: {acc_count:,} records\")\nprint(f\"  Separations: {sep_count:,} records\")\nprint(f\"  Employment: {emp_count:,} records\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Add `union_by_name=True` to `read_parquet` calls in cell-6 so months with differing columns load cleanly (202602 accessions dropped `duty_station_state_code` vs 202601, which broke the default strict-schema glob).
- Set `HF_HUB_DISABLE_IMPLICIT_TOKEN=1` at the top of cell-2 to suppress Colab's HF_TOKEN lookup warning — the datasets are public, no auth needed.

## Test plan
- [x] Verified locally: `read_parquet([202601, 202602], union_by_name=True)` returns 27,836 rows with 65 columns (union of schemas).
- [ ] Run demo.ipynb in Colab end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)